### PR TITLE
basic card style

### DIFF
--- a/app/assets/stylesheets/components/_card_tank.scss
+++ b/app/assets/stylesheets/components/_card_tank.scss
@@ -1,0 +1,54 @@
+.card-tank {
+  overflow: hidden;
+  background: white;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  width: 600px;
+  height: 400px;
+}
+
+.card-tank > img {
+  padding: 16px;
+  height: 320px;
+  width: 100%;
+  object-fit: cover;
+}
+
+.card-tank h2 {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.card-tank p {
+  font-size: 12px;
+  opacity: .7;
+  margin: 0;
+}
+
+
+.card-tank .card-tank-infos {
+  padding: 16px;
+//   display: flex;
+//   justify-content: space-between;
+//   align-items: flex-end;
+//   position: relative;
+}
+
+.card-tank-headers {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 4px;
+}
+
+.card-tank-values {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+}
+
+// .card-tank-infos .card-tank-user {
+//   position: absolute;
+//   right: 16px;
+//   top: -20px;
+//   width: 40px;
+// }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -2,3 +2,5 @@
 @import "alert";
 @import "avatar";
 @import "navbar";
+@import "footer";
+@import "card_tank";

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,11 +11,21 @@
 <!-- Tanks-->
 <div class="">
   <% Tank.all.each do |tank| %>
-    <div class="tank-card">
-      <%= tank.name  %>
-      <%= tank.description  %>
-      <br>
-      <%= tank.price_per_day %> | <%= tank.capacity %>
+    <div class="card-tank">
+      <img src="https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/greece.jpg" />
+        <div class="card-tank-infos">
+          <div class="card-tank-headers">
+            <p>MODEL</p>
+            <p>CAPACITY</p>
+            <p>price/day</p>
+          </div>
+          <div class="card-tank-values">
+            <p><%= tank.name  %></p>
+            <p><%= tank.capacity %></p>
+            <h2 class="card-tank-pricing"><%= tank.price_per_day %>€</h2>
+          </div>
+        <br>
+      </div>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
here is the basic card style

still to fix:

that the headers (MODEL CAPACITY price/day) and values (centurion 4 100€) get displayed in nice columns
the space between on euch row(headers or values) seems not to fix the middle item ... maybe flex grow?